### PR TITLE
fixed displayed fees for polar path

### DIFF
--- a/components/Switch.tsx
+++ b/components/Switch.tsx
@@ -202,7 +202,13 @@ export const SwitchComponent: FC = () => {
       const transactionFee = await transaction.paymentInfo(sourceAccount);
 
       setTransaction(transaction);
-      setFeeDisplay(transactionFee.partialFee.toHuman());
+      const rawFee = transactionFee.partialFee.toHuman().replace(/,/g, ""); 
+      const transferFeeFormatted = formatBalance({
+        number: BigInt(rawFee), 
+        decimals: 15, 
+        displayDecimals: 15,
+      });
+      setFeeDisplay(transferFeeFormatted);
     } catch (err) {
       console.error(err);
       setError({
@@ -537,7 +543,7 @@ export const SwitchComponent: FC = () => {
                 </div>
               </div>
               <div className="text-sm text-right text-muted-foreground px-1">
-                Transfer Fee: {feeDisplay}
+                Transfer Fee: {feeDisplay} {tokenSymbol ?? ""}
                 <br />
                 {sourceId === "assethub" ? null : (
                   <>


### PR DESCRIPTION
## fixes KILTProtocol/ticket#3703
I fixed the fee display for Polar Path. The fees are fetched from the transaction info as partial fees. These fees are retrieved as a big number and divided by 10^15, with all 15 decimals displayed in this fix. However, this behavior can be adjusted if needed.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
